### PR TITLE
Feature: Extend rules to allow multiple words in class

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+# Pull request checklist
+
+- [ ] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
+- [ ] Make sure you are requesting the right branch.
+- [ ] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
+- [ ] Ensure all tests are passing.
+
+# PR type
+
+- Bug fix / new feature / chore
+
+# Description
+
+- Describe what this pull request is for.
+- What will it affect.

--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ function FancyProfileCard() {
   return <div className="FancyProfileCard" />;
 }
 ```
+
+## Pull Requests
+
+Please run `npm run build | yarn build` before submitting a PR for the time being

--- a/lib/rules/classNamingRule/classNamingRule.js
+++ b/lib/rules/classNamingRule/classNamingRule.js
@@ -23,6 +23,8 @@ var testClassName = function testClassName(context, node) {
   if (!value || type !== 'Literal') {
     return false;
   }
+  /* check for spaces at the start and end of the string Literal */
+
 
   var firstLetter = value[0];
   var lastLetter = value[value.length - 1];
@@ -45,24 +47,31 @@ var testClassName = function testClassName(context, node) {
     });
     return true;
   }
+  /* check each word in the string Literal for its casing */
 
-  if (firstLetter !== firstLetter.toUpperCase()) {
-    return false;
-  }
 
-  var camelCasedClassName = value.charAt(0).toLowerCase() + value.slice(1);
-  context.report({
-    fix: function fix(fixer) {
-      if (!canFix) {
-        return null;
-      }
+  var classNameArray = value.split(" ");
+  classNameArray.forEach(function (className) {
+    var classNameFirstLetter = className[0];
 
-      return fixer.replaceTextRange([firstLetterInRange, lastLetterInRange], camelCasedClassName);
-    },
-    message: 'class name should be camelCase',
-    node: node
+    if (classNameFirstLetter !== classNameFirstLetter.toUpperCase()) {
+      return false;
+    }
+
+    var updatedClassName = value.replace(className, className.charAt(0).toLowerCase() + className.slice(1));
+    context.report({
+      fix: function fix(fixer) {
+        if (!canFix) {
+          return null;
+        }
+
+        return fixer.replaceTextRange([firstLetterInRange, lastLetterInRange], updatedClassName);
+      },
+      message: 'class name should be camelCase',
+      node: node
+    });
+    return true;
   });
-  return true;
 };
 
 var classNamingRule = {

--- a/lib/rules/classNamingRule/classNamingRule.test.js
+++ b/lib/rules/classNamingRule/classNamingRule.test.js
@@ -24,6 +24,12 @@ ruleTester.run('classNaming', _classNamingRule.classNamingRule, {
   }, {
     code: 'function Accordion(props) { return (<div className="accordion">hello world</div>)}',
     options: []
+  }, {
+    code: 'function Accordion(props) { return (<div className="accordion extraClassName">hello world</div>)}',
+    options: []
+  }, {
+    code: 'function Accordion(props) { return (<div className="accordion extraClassName anotherClassName">hello world</div>)}',
+    options: []
   }],
   invalid: [// with fix = true, camelCasing
   {
@@ -117,6 +123,38 @@ ruleTester.run('classNaming', _classNamingRule.classNamingRule, {
       fix: true
     }],
     output: 'function Accordion(props) { return (<div className="helloWorld">hello world</div>)}'
+  }, // with fix = true, multi word classNames
+  {
+    code: 'function Accordion(props) { return (<div className="helloWorld HiThere">hello world</div>)}',
+    errors: [{
+      message: 'class name should be camelCase',
+      type: 'JSXIdentifier'
+    }],
+    options: [{
+      fix: true
+    }],
+    output: 'function Accordion(props) { return (<div className="helloWorld hiThere">hello world</div>)}'
+  }, {
+    code: 'function Accordion(props) { return (<div className="HelloWorld hiThere">hello world</div>)}',
+    errors: [{
+      message: 'class name should be camelCase',
+      type: 'JSXIdentifier'
+    }],
+    options: [{
+      fix: true
+    }],
+    output: 'function Accordion(props) { return (<div className="helloWorld hiThere">hello world</div>)}'
+  }, {
+    // weird example
+    code: 'function Accordion(props) { return (<div className="helloWorld HelloWorld__whatever">hello world</div>)}',
+    errors: [{
+      message: 'class name should be camelCase',
+      type: 'JSXIdentifier'
+    }],
+    options: [{
+      fix: true
+    }],
+    output: 'function Accordion(props) { return (<div className="helloWorld helloWorld__whatever">hello world</div>)}'
   }, // with fix = false, camelCasing
   {
     code: 'function Accordion(props) { return (<div className="Accordion">hello world</div>)}',
@@ -157,5 +195,16 @@ ruleTester.run('classNaming', _classNamingRule.classNamingRule, {
     }],
     options: [],
     output: 'function Accordion(props) { return (<div className=" helloWorld ">hello world</div>)}'
+  }, // with fix = false, multi word classNames
+  {
+    code: 'function Accordion(props) { return (<div className="helloWorld HiThere">hello world</div>)}',
+    errors: [{
+      message: 'class name should be camelCase',
+      type: 'JSXIdentifier'
+    }],
+    options: [{
+      fix: false
+    }],
+    output: 'function Accordion(props) { return (<div className="helloWorld HiThere">hello world</div>)}'
   }]
 });

--- a/src/rules/classNamingRule/classNamingRule.mjs
+++ b/src/rules/classNamingRule/classNamingRule.mjs
@@ -14,6 +14,8 @@ const testClassName = (context, node) => {
     return false;
   }
 
+  /* check for spaces at the start and end of the string Literal */
+
   const firstLetter = value[0];
   const lastLetter = value[value.length - 1];
   const canFix = context.options.length > 0 && context.options[0].fix;
@@ -36,25 +38,31 @@ const testClassName = (context, node) => {
     return true;
   }
 
-  if (firstLetter !== firstLetter.toUpperCase()) {
-    return false;
-  }
+  /* check each word in the string Literal for its casing */
+  const classNameArray = value.split(" ")
 
-  const camelCasedClassName = value.charAt(0).toLowerCase() + value.slice(1);
+  classNameArray.forEach(className => {
+    const classNameFirstLetter = className[0];
+    if (classNameFirstLetter !== classNameFirstLetter.toUpperCase()) {
+      return false;
+    }
 
-  context.report({
-    fix: (fixer) => {
-      if (!canFix) {
-        return null;
-      }
+    const camelCasedClassName = className.charAt(0).toLowerCase() + className.slice(1);
 
-      return fixer.replaceTextRange([firstLetterInRange, lastLetterInRange], camelCasedClassName);
-    },
-    message: 'class name should be camelCase',
-    node
+    context.report({
+      fix: (fixer) => {
+        if (!canFix) {
+          return null;
+        }
+
+        return fixer.replaceTextRange([firstLetterInRange, lastLetterInRange], camelCasedClassName);
+      },
+      message: 'class name should be camelCase',
+      node
+    });
+
+    return true;
   });
-
-  return true;
 };
 
 export const classNamingRule = {

--- a/src/rules/classNamingRule/classNamingRule.mjs
+++ b/src/rules/classNamingRule/classNamingRule.mjs
@@ -47,7 +47,7 @@ const testClassName = (context, node) => {
       return false;
     }
 
-    const camelCasedClassName = className.charAt(0).toLowerCase() + className.slice(1);
+    const updatedClassName = value.replace(className, className.charAt(0).toLowerCase() + className.slice(1));
 
     context.report({
       fix: (fixer) => {
@@ -55,7 +55,7 @@ const testClassName = (context, node) => {
           return null;
         }
 
-        return fixer.replaceTextRange([firstLetterInRange, lastLetterInRange], camelCasedClassName);
+        return fixer.replaceTextRange([firstLetterInRange, lastLetterInRange], updatedClassName);
       },
       message: 'class name should be camelCase',
       node

--- a/src/rules/classNamingRule/classNamingRule.test.js
+++ b/src/rules/classNamingRule/classNamingRule.test.js
@@ -25,6 +25,14 @@ ruleTester.run('classNaming', classNamingRule, {
     {
       code: 'function Accordion(props) { return (<div className="accordion">hello world</div>)}',
       options: []
+    },
+    {
+      code: 'function Accordion(props) { return (<div className="accordion extraClassName">hello world</div>)}',
+      options: []
+    },
+    {
+      code: 'function Accordion(props) { return (<div className="accordion extraClassName anotherClassName">hello world</div>)}',
+      options: []
     }
   ],
   invalid: [
@@ -129,6 +137,18 @@ ruleTester.run('classNaming', classNamingRule, {
       options: [{fix: true}],
       output: 'function Accordion(props) { return (<div className="helloWorld">hello world</div>)}'
     },
+    // with fix = true, multi word classNames
+    {
+      code: 'function Accordion(props) { return (<div className="helloWorld HiThere">hello world</div>)}',
+      errors: [
+        {
+          message: 'class name should be camelCase',
+          type: 'JSXIdentifier'
+        }
+      ],
+      options: [{fix: true}],
+      output: 'function Accordion(props) { return (<div className="helloWorld hiThere">hello world</div>)}'
+    },
 
     // with fix = false, camelCasing
     {
@@ -177,6 +197,19 @@ ruleTester.run('classNaming', classNamingRule, {
       ],
       options: [],
       output: 'function Accordion(props) { return (<div className=" helloWorld ">hello world</div>)}'
-    }
+    },
+
+    // with fix = false, multi word classNames
+    {
+      code: 'function Accordion(props) { return (<div className="helloWorld HiThere">hello world</div>)}',
+      errors: [
+        {
+          message: 'class name should be camelCase',
+          type: 'JSXIdentifier'
+        }
+      ],
+      options: [{fix: false}],
+      output: 'function Accordion(props) { return (<div className="helloWorld HiThere">hello world</div>)}'
+    },
   ]
 });

--- a/src/rules/classNamingRule/classNamingRule.test.js
+++ b/src/rules/classNamingRule/classNamingRule.test.js
@@ -160,6 +160,17 @@ ruleTester.run('classNaming', classNamingRule, {
       options: [{fix: true}],
       output: 'function Accordion(props) { return (<div className="helloWorld hiThere">hello world</div>)}'
     },
+    { // weird example
+      code: 'function Accordion(props) { return (<div className="helloWorld HelloWorld__whatever">hello world</div>)}',
+      errors: [
+        {
+          message: 'class name should be camelCase',
+          type: 'JSXIdentifier'
+        }
+      ],
+      options: [{fix: true}],
+      output: 'function Accordion(props) { return (<div className="helloWorld helloWorld__whatever">hello world</div>)}'
+    },
 
     // with fix = false, camelCasing
     {

--- a/src/rules/classNamingRule/classNamingRule.test.js
+++ b/src/rules/classNamingRule/classNamingRule.test.js
@@ -149,6 +149,17 @@ ruleTester.run('classNaming', classNamingRule, {
       options: [{fix: true}],
       output: 'function Accordion(props) { return (<div className="helloWorld hiThere">hello world</div>)}'
     },
+    {
+      code: 'function Accordion(props) { return (<div className="HelloWorld hiThere">hello world</div>)}',
+      errors: [
+        {
+          message: 'class name should be camelCase',
+          type: 'JSXIdentifier'
+        }
+      ],
+      options: [{fix: true}],
+      output: 'function Accordion(props) { return (<div className="helloWorld hiThere">hello world</div>)}'
+    },
 
     // with fix = false, camelCasing
     {


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure you are requesting the right branch.
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure all tests are passing.

# PR type

- new feature

# Description

- Support multi word classnames such as `className="oneWord twoWord threeWord"`
- ensure everything still works
